### PR TITLE
Fix inconsistent decoration RNG

### DIFF
--- a/Assets/Scripts/LevelDecorator/PatternMatchingDecoratorRule.cs
+++ b/Assets/Scripts/LevelDecorator/PatternMatchingDecoratorRule.cs
@@ -52,6 +52,7 @@ public class PatternMatchingDecoratorRule : BaseDecoratorRule
         decoration.transform.eulerAngles = currentRotation + new Vector3(0f, prefabRotation, 0f);
         Vector3 center = new Vector3(occurrance.x + placement.Width / 2f, 0f, occurrance.y + placement.Height / 2f);
         int scale = SharedLevelData.Instance.Scale;
+        // Position the decoration so its center aligns with the pattern position at the current scale.
         decoration.transform.position = (center + new Vector3(-1, 0, -1)) * scale;
         decoration.transform.localScale = Vector3.one * scale;
 

--- a/Assets/Scripts/LevelDecorator/RoomDecorator.cs
+++ b/Assets/Scripts/LevelDecorator/RoomDecorator.cs
@@ -35,7 +35,8 @@ public class RoomDecorator : MonoBehaviour
     [ContextMenu("Place Items")]
     public void PlaceItemsFromMenu()
     {
-        random = SharedLevelData.Instance.Rand;
+        // Start the RNG from the same seed each time decorations are regenerated.
+        SharedLevelData.Instance.ResetRandom();
         Level level = roomLayoutGenerator.GenerateLevel();
         PlaceItems(level);
     }
@@ -52,6 +53,8 @@ public class RoomDecorator : MonoBehaviour
 
     public void PlaceItems(Level level)
     {
+        // Reset ensures deterministic decoration regardless of prior RNG usage.
+        SharedLevelData.Instance.ResetRandom();
         random = SharedLevelData.Instance.Rand;
         Transform decorationsTransform = parent.transform.Find("Decorations");
         if (decorationsTransform == null)
@@ -99,6 +102,7 @@ public class RoomDecorator : MonoBehaviour
         int maxTries = 50;
         int currentTries = 0;
 
+        // Determine how many props can appear in this room based on its area.
         int maxNumDecorations = (int)(room.Area.width * room.Area.height * decorationDensity);
         int currentDecorations = 0;
 


### PR DESCRIPTION
## Summary
- reset RNG before placing decorations so decoration placement remains deterministic
- clarify decoration limit calculation with a comment
- explain decoration positioning math

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ab52432388330a4a1a9d1f1c62ce4